### PR TITLE
fixed batch size and temperature settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Parameters that control the evaluation process.
   * `timeout_minutes`: The maximum time in minutes to allow for a single task before it times out. Default is 30.
   * `runs_per_eval`: How many times to repeat each evaluation task for a given model. The final CSV will include a `run_id` column.
   * `output_dir`: The directory where result CSVs and logs will be saved.
+  * `temperature`: Ranging from 0 to 1.0
+  * `batch size`: To set batch size for gsm8k, you first need to comment out `--use_vllm` in ./evaluators/harness_evaluator.py. Otherwise, vllm will set the batch size automatically. Also, you need to make sure you are only using 1 GPU if you want to try different batch sizes for gsm8k evaluations.
 
 ### `environment_config`
 

--- a/evaluators/language_evaluator.py
+++ b/evaluators/language_evaluator.py
@@ -14,30 +14,28 @@ class LanguageEvaluator(BaseEvaluator):
         
         gpu_ids = self.eval_settings.get("gpu_ids", "0")
         num_gpus = len(gpu_ids.split(','))
+        
+        temperature = self.eval_settings.get("temperature", 0.0)
+        batch_size = self.eval_settings.get("batch_size", 1)
 
-        # Set environment variables for the subprocess to see
-        # PYTHONPATH is crucial for local imports
         os.environ["PYTHONPATH"] = os.path.abspath(eval_dir) + os.pathsep + os.environ.get("PYTHONPATH", "")
-        # CUDA_VISIBLE_DEVICES tells torchrun which GPUs are available
         os.environ["CUDA_VISIBLE_DEVICES"] = gpu_ids
         
         eval_script_path = os.path.abspath(os.path.join(eval_dir, "eval_pal.py"))
         dataroot_path = os.path.abspath(os.path.join(eval_dir, "data/"))
-        log_dir_path = os.path.abspath(os.path.join(eval_dir, "logs/"))
-        
-        # Create logs directory if it doesn't exist
-        os.makedirs(log_dir_path, exist_ok=True)
+
+        base_command_args = [
+            eval_script_path,
+            "--logdir", model_path,
+            "--language", task_name,
+            "--dataroot", dataroot_path,
+            "--temperature", str(temperature),
+            "--batch_size", str(batch_size)
+        ]
 
         if num_gpus <= 1:
             print("\n[INFO] Single GPU detected. Running with simple 'python' command.\n")
-            command = [
-                "python",
-                eval_script_path,
-                "--model_path", model_path,
-                "--log_dir", log_dir_path,
-                "--language", task_name,
-                "--dataroot", dataroot_path
-            ]
+            command = ["python"] + base_command_args
         else:
             print(f"\n[INFO] {num_gpus} GPUs detected. Using 'torchrun' for distributed evaluation.\n")
             master_port = random.randint(20000, 29999)
@@ -45,11 +43,6 @@ class LanguageEvaluator(BaseEvaluator):
                 "torchrun",
                 "--nproc_per_node", str(num_gpus),
                 "--master_port", str(master_port),
-                eval_script_path,
-                "--model_path", model_path,
-                "--log_dir", log_dir_path,
-                "--language", task_name,
-                "--dataroot", dataroot_path
-            ]
+            ] + base_command_args
         
         return command, eval_dir, env_name

--- a/vendor/math-evaluation-harness/math_eval.py
+++ b/vendor/math-evaluation-harness/math_eval.py
@@ -39,6 +39,7 @@ def parse_args():
     parser.add_argument("--save_outputs", action="store_true")
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--use_safetensors", action="store_true")
+    parser.add_argument("--batch_size", default=32, type=int)
     args = parser.parse_args()
     args.top_p = 1 if args.temperature == 0 else args.top_p # top_p must be 1 when using greedy sampling (vllm)
     return args
@@ -197,8 +198,11 @@ def main(llm, tokenizer, data_name, args):
                 tokenizer=tokenizer,
                 prompts=prompts,
                 max_new_tokens=args.max_tokens_per_call,
-                batch_size=16,
+                batch_size=args.batch_size,
                 stop_id_sequences=stop_words,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                do_sample=False if args.temperature == 0 else True
             )
 
         assert len(outputs) == len(current_prompts)


### PR DESCRIPTION
1. Language evaluations, Humaneval, and GSM8K are now able to correctly accept batch size and temperature from the config.
2. To set batch size for gsm8k, you first need to comment out `--use_vllm` in ./evaluators/harness_evaluator.py. Otherwise, vllm will set the batch size automatically. Also, you need to make sure you are only using 1 GPU if you want to try different batch sizes for gsm8k evaluations. 